### PR TITLE
Update watermark.js

### DIFF
--- a/watermark.js
+++ b/watermark.js
@@ -62,6 +62,7 @@
     'childList': true,
     'attributes': true,
     'subtree': true,
+    'characterData':true
   };
 
   /*加载水印*/
@@ -69,7 +70,7 @@
     /*采用配置项替换默认值，作用类似jquery.extend*/
     if(arguments.length===1&&typeof arguments[0] ==="object" ){
       var src=arguments[0]||{};
-      for(key in src)
+      for(var key in src)
       {
         if(src[key]&&defaultSettings[key]&&src[key]===defaultSettings[key])continue;
         /*veronic: resolution of watermark_angle=0 not in force*/
@@ -90,7 +91,7 @@
     var page_width = Math.max(watermark_hook_element.scrollWidth,watermark_hook_element.clientWidth);
     /*获取页面最大长度*/
     // var page_height = Math.max(watermark_hook_element.scrollHeight,watermark_hook_element.clientHeight,document.documentElement.clientHeight)-defaultSettings.watermark_height/2;
-    var page_height = Math.max(watermark_hook_element.scrollHeight,watermark_hook_element.clientHeight);
+    var page_height = watermark_hook_element.clientHeight;
 
     var setting = arguments[0]||{};
     var parentEle = watermark_hook_element;
@@ -185,7 +186,7 @@
         mask_div.style.OTransform = "rotate(-" + defaultSettings.watermark_angle + "deg)";
         mask_div.style.transform = "rotate(-" + defaultSettings.watermark_angle + "deg)";
         mask_div.style.visibility = "";
-        mask_div.style.position = "absolute";
+        mask_div.style.position = "fixed";
         /*选不中*/
         mask_div.style.left = x + 'px';
         mask_div.style.top = y + 'px';
@@ -206,8 +207,8 @@
     }
 
     // monitor 是否监控， true: 不可删除水印; false: 可删水印。
-    const minotor = settings.monitor === undefined ? defaultSettings.monitor : settings.monitor;
-    if (minotor && hasObserver) {
+    const monitor = settings.monitor === undefined ? defaultSettings.monitor : settings.monitor;
+    if (monitor && hasObserver) {
       watermarkDom.observe(watermark_hook_element, option);
       watermarkDom.observe(document.getElementById(defaultSettings.watermark_id).shadowRoot, option);
     }
@@ -219,7 +220,7 @@
     if(arguments.length===1&&typeof arguments[0] ==="object" )
     {
       var src=arguments[0]||{};
-      for(key in src)
+      for(var key in src)
       {
         if(src[key]&&defaultSettings[key]&&src[key]===defaultSettings[key])continue;
         /*veronic: resolution of watermark_angle=0 not in force*/
@@ -232,7 +233,7 @@
     var _parentElement = watermark_element.parentNode;
     _parentElement.removeChild(watermark_element);
     // :ambulance: remove()
-    // minotor 这个配置有些冗余
+    // monitor 这个配置有些冗余
     // 如果用 MutationObserver 来监听dom变化防止删除水印
     // remove() 方法里用 MutationObserver 的 disconnect() 解除监听即可
     watermarkDom.disconnect();
@@ -262,40 +263,5 @@
     forceRemove = true;
     removeMark();
   };
-
-
-  //监听dom是否被移除或者改变属性的回调函数
-  var callback = function (records){
-    if ((globalSetting && records.length === 1) || records.length === 1 && records[0].removedNodes.length >= 1) {
-      loadMark(globalSetting);
-      return;
-    }
-
-    // 监听父节点的尺寸是否发生了变化, 如果发生改变, 则进行重新绘制
-    var watermark_parent_element = document.getElementById(defaultSettings.watermark_parent_node);
-    if (watermark_parent_element) {
-      var newWidth = getComputedStyle(watermark_parent_element).getPropertyValue('width');
-      var newHeight = getComputedStyle(watermark_parent_element).getPropertyValue('height');
-      if (newWidth !== recordOldValue.width || newHeight !== recordOldValue.height) {
-        recordOldValue.width = newWidth;
-        recordOldValue.height = newHeight;
-        loadMark(globalSetting);
-      }
-    }
-  };
-  const MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
-  var watermarkDom = new MutationObserver(callback);
-  var option = {
-    'childList': true,
-    'attributes': true,
-    'subtree': true,
-    'attributeFilter': ['style'],
-    'attributeOldValue': true
-  };
-  var recordOldValue = {
-    width: 0,
-    height: 0
-  }
-
   return watermark;
 }));


### PR DESCRIPTION
1. 将水印的高度计算使用 `clientHeight `，水印的定位样式改为：`position: fixed`，目的在于解决页面数据动态增加后，水印相印的撑开页面，页面数据减少后，水印仍然撑开页面导致底部出现大块的空白。在 vue 框架下，使用 tab 组件或表格筛选数据时会出现这样的问题。
2. `mutationObserver.observer` 监测父节点选项 `subtree: false`，此为节省性能，同时也能起到防止水印被删除。
2. 移除底部未使用的代码